### PR TITLE
Bugfix for geothermal plant loading

### DIFF
--- a/game.py
+++ b/game.py
@@ -196,14 +196,21 @@ def load_game(filename="savegame.json"):
                 level = 1 # Default level for old save format
 
             building_class = BUILDING_CLASSES.get(name)
+            if not building_class:
+                # Support loading buildings saved with display names that don't
+                # match the dictionary keys (e.g. "Geothermal Plant" vs
+                # "GeothermalPlant").
+                normalized_name = name.replace(" ", "") if isinstance(name, str) else name
+                building_class = BUILDING_CLASSES.get(normalized_name)
+
             if building_class:
                 building_instance = building_class()
-                building_instance.level = level # Set the loaded level
+                building_instance.level = level  # Set the loaded level
                 new_colony.add_building(building_instance)
             else:
-                # print(f"Warning: Building class for '{name}' not found during load. Skipping.") # CLI
-                # For curses, this kind of warning might be logged differently or ignored for cleaner UI
-                pass # Silently skip for now, or log to a file/internal game log
+                # Silently skip unknown building types. In a full game we might
+                # want to log this for debugging.
+                pass
         
         # Load research data
         new_colony.completed_research = set(data.get("completed_research", []))

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -58,6 +58,18 @@ class TestGameLoadSave(unittest.TestCase):
         self.assertIsInstance(loaded_colony.buildings[0], Mine)
         self.assertEqual(loaded_colony.buildings[0].level, target_level, "Building level not saved/loaded correctly.")
 
+    def test_save_load_geothermal_plant(self):
+        colony = Colony()
+        gp = GeothermalPlant()
+        colony.add_building(gp)
+
+        save_game(colony, self.save_filename)
+        loaded_colony = load_game(self.save_filename)
+
+        self.assertIsNotNone(loaded_colony)
+        self.assertEqual(len(loaded_colony.buildings), 1)
+        self.assertIsInstance(loaded_colony.buildings[0], GeothermalPlant)
+
     def test_save_load_research_state(self):
         colony = Colony()
         initial_rp = 500


### PR DESCRIPTION
## Summary
- fix `load_game` so buildings saved with display names load correctly
- add regression test to ensure `GeothermalPlant` saves and loads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407bf08db88327bbf048fb5c61d3e5