### PR TITLE
Add solar flare event and building damage

### DIFF
--- a/colony.py
+++ b/colony.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import random
 from research import RESEARCH_PROJECTS # Import RESEARCH_PROJECTS
 
 class Colony:
@@ -63,6 +64,22 @@ class Colony:
 
     def get_buildings(self):
         return self.buildings
+
+    def damage_random_building(self):
+        """Randomly damages one of the colony's buildings.
+        If the selected building is level 1 it is destroyed.
+        Returns a short description of the damage.
+        """
+        if not self.buildings:
+            return "No buildings to damage."
+
+        building = random.choice(self.buildings)
+        if building.level > 1:
+            building.level -= 1
+            return f"{building.name} damaged and downgraded to level {building.level}."
+        else:
+            self.buildings.remove(building)
+            return f"{building.name} destroyed."
 
     def has_enough_resources(self, cost_dict):
         for resource_name, required_amount in cost_dict.items():

--- a/events.py
+++ b/events.py
@@ -80,6 +80,21 @@ class ProductionSpike(Event):
         
         return f"{self.name}: Systems surged, granting an instant bonus of {bonus_minerals:.1f} Minerals and {bonus_energy:.1f} Energy."
 
+class SolarFlare(Event):
+    def __init__(self):
+        super().__init__(
+            name="Solar Flare",
+            description="An intense solar flare disrupts colony systems."
+        )
+
+    def apply(self, colony):
+        lost_energy = float(random.randint(20, 40))
+        current = colony.get_resources().get("Energy", 0.0)
+        actual = min(lost_energy, current)
+        if actual > 0:
+            colony.resources["Energy"] = max(0.0, current - actual)
+        return f"{self.name}: Lost {actual:.1f} Energy due to radiation interference."
+
 class MeteorStrikeWarning(Event):
     def __init__(self):
         super().__init__(
@@ -108,7 +123,8 @@ class MeteorStrikeWarning(Event):
                     actual_energy_loss = min(lost_energy_amount, current_energy)
                     if actual_energy_loss > 0:
                         colony.resources["Energy"] = max(0.0, current_energy - actual_energy_loss)
-                    outcome_message += f"Defense failed! Lost {actual_energy_loss:.1f} additional Energy and some equipment was damaged."
+                    outcome_message += f"Defense failed! Lost {actual_energy_loss:.1f} additional Energy. "
+                    outcome_message += colony.damage_random_building()
             else:
                 outcome_message += "Not enough Energy to attempt defense! Bracing for impact instead. "
                 # Fall through to brace logic
@@ -117,7 +133,8 @@ class MeteorStrikeWarning(Event):
                 actual_mineral_loss = min(lost_minerals_amount, current_minerals)
                 if actual_mineral_loss > 0:
                     colony.resources["Minerals"] = max(0.0, current_minerals - actual_mineral_loss)
-                outcome_message += f"Lost {actual_mineral_loss:.1f} Minerals during impact."
+                outcome_message += f"Lost {actual_mineral_loss:.1f} Minerals during impact. "
+                outcome_message += colony.damage_random_building()
 
         elif choice_key == "brace":
             if random.random() < 0.30: # 30% no damage
@@ -128,6 +145,7 @@ class MeteorStrikeWarning(Event):
                 actual_mineral_loss = min(lost_minerals_amount, current_minerals)
                 if actual_mineral_loss > 0:
                     colony.resources["Minerals"] = max(0.0, current_minerals - actual_mineral_loss)
-                outcome_message += f"Braced for impact. Lost {actual_mineral_loss:.1f} Minerals. Some buildings might need repair (feature not yet implemented)."
+                outcome_message += f"Braced for impact. Lost {actual_mineral_loss:.1f} Minerals. "
+                outcome_message += colony.damage_random_building()
         
         return outcome_message

--- a/game.py
+++ b/game.py
@@ -3,7 +3,7 @@ import os # For checking file existence
 import random # For event triggering
 from colony import Colony
 from buildings import Mine, SolarPanel, HydroponicsFarm, ResearchLab, GeothermalPlant # Added GeothermalPlant
-from events import Event, MinorResourceBoost, SmallResourceDrain, ProductionSpike, MeteorStrikeWarning
+from events import Event, MinorResourceBoost, SmallResourceDrain, ProductionSpike, MeteorStrikeWarning, SolarFlare
 
 # Base per-second production rates
 BASE_MINERALS_PER_SECOND = 1.0
@@ -235,7 +235,7 @@ def load_game(filename="savegame.json"):
         # print(f"An unexpected error occurred while loading the game: {e}") # CLI print
         return None
 
-AVAILABLE_EVENT_CLASSES = [MinorResourceBoost, SmallResourceDrain, ProductionSpike, MeteorStrikeWarning]
+AVAILABLE_EVENT_CLASSES = [MinorResourceBoost, SmallResourceDrain, ProductionSpike, SolarFlare, MeteorStrikeWarning]
 
 def trigger_random_event(colony_instance, available_event_classes):
     """

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,38 @@
+import unittest
+import random
+
+from colony import Colony
+from buildings import Mine
+from events import SolarFlare
+
+class TestEventConsequences(unittest.TestCase):
+    def test_damage_random_building_downgrade(self):
+        colony = Colony()
+        mine = Mine()
+        mine.level = 2
+        colony.add_building(mine)
+        random.seed(1)
+        msg = colony.damage_random_building()
+        self.assertIn("damaged", msg)
+        self.assertEqual(colony.buildings[0].level, 1)
+
+    def test_damage_random_building_destroy(self):
+        colony = Colony()
+        mine = Mine()
+        colony.add_building(mine)
+        random.seed(1)
+        msg = colony.damage_random_building()
+        self.assertIn("destroyed", msg)
+        self.assertEqual(len(colony.buildings), 0)
+
+    def test_solar_flare_energy_loss(self):
+        colony = Colony()
+        colony.resources["Energy"] = 50.0
+        random.seed(1)
+        event = SolarFlare()
+        message = event.apply(colony)
+        self.assertIn("Lost", message)
+        self.assertLess(colony.resources["Energy"], 50.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `damage_random_building` to `Colony`
- implement `SolarFlare` event
- introduce building damage consequences in `MeteorStrikeWarning`
- register new event in the game and update tests
- add unit tests for new event and building damage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68424f9a1d50832793110df46595e27d