### PR TITLE
Add web-based 3D UI

### DIFF
--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Colony Builder</title>
+    <style>
+        body { margin:0; overflow:hidden; font-family: Arial, sans-serif; }
+        #ui { position:absolute; top:10px; left:10px; background:rgba(255,255,255,0.8); padding:10px; border-radius:4px; }
+        button { margin-right:5px; margin-bottom:5px; }
+    </style>
+</head>
+<body>
+<div id="ui">
+    <div id="resources">Loading...</div>
+    <button id="buildBtn">Build</button>
+    <button id="upgradeBtn">Upgrade</button>
+    <button id="researchBtn">Research</button>
+</div>
+<script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/web-ui/main.js
+++ b/web-ui/main.js
@@ -1,0 +1,109 @@
+import * as THREE from 'three';
+
+let scene, camera, renderer;
+const buildings = [];
+
+function initScene() {
+    scene = new THREE.Scene();
+    camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera.position.set(5, 5, 5);
+    camera.lookAt(0, 0, 0);
+
+    const light = new THREE.DirectionalLight(0xffffff, 1);
+    light.position.set(5, 10, 7.5);
+    scene.add(light);
+
+    const ambient = new THREE.AmbientLight(0x404040);
+    scene.add(ambient);
+
+    renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(renderer.domElement);
+
+    const grid = new THREE.GridHelper(10, 10);
+    scene.add(grid);
+
+    animate();
+    window.addEventListener('resize', onWindowResize);
+}
+
+function onWindowResize() {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function animate() {
+    requestAnimationFrame(animate);
+    renderer.render(scene, camera);
+}
+
+function addBuilding(x, z) {
+    const geometry = new THREE.BoxGeometry(1, 1, 1);
+    const material = new THREE.MeshLambertMaterial({ color: 0x808080 });
+    const cube = new THREE.Mesh(geometry, material);
+    cube.position.set(x, 0.5, z);
+    scene.add(cube);
+    buildings.push({ x, z });
+}
+
+// Placeholder API functions
+async function fetchState() {
+    try {
+        const res = await fetch('/api/state');
+        return await res.json();
+    } catch (e) {
+        console.error('Failed to fetch state', e);
+        return null;
+    }
+}
+
+async function sendAction(action, payload) {
+    try {
+        const res = await fetch('/api/action', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ action, payload })
+        });
+        return await res.json();
+    } catch (e) {
+        console.error('Failed to send action', e);
+        return null;
+    }
+}
+
+function updateUI(state) {
+    const resDiv = document.getElementById('resources');
+    if (!state) {
+        resDiv.textContent = 'Offline';
+        return;
+    }
+    resDiv.textContent = `Minerals: ${state.minerals} | Energy: ${state.energy}`;
+
+    scene.children.filter(o => o.userData.building).forEach(o => scene.remove(o));
+    state.buildings.forEach(b => addBuilding(b.x, b.z));
+}
+
+async function pollState() {
+    const state = await fetchState();
+    updateUI(state);
+}
+
+initScene();
+
+setInterval(pollState, 2000);
+
+document.getElementById('buildBtn').onclick = async () => {
+    await sendAction('build', { type: 'mine' });
+    pollState();
+};
+
+document.getElementById('upgradeBtn').onclick = async () => {
+    await sendAction('upgrade', {});
+    pollState();
+};
+
+document.getElementById('researchBtn').onclick = async () => {
+    await sendAction('research', {});
+    pollState();
+};

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "web-ui",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/web-ui/server.js
+++ b/web-ui/server.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+
+app.use(express.json());
+app.use(express.static(__dirname));
+
+// Simple in-memory game state
+const state = {
+    minerals: 100,
+    energy: 50,
+    buildings: []
+};
+
+app.get('/api/state', (req, res) => {
+    res.json(state);
+});
+
+app.post('/api/action', (req, res) => {
+    const { action, payload } = req.body;
+    if (action === 'build') {
+        state.buildings.push({ x: Math.random()*4-2, z: Math.random()*4-2, type: payload.type });
+        state.minerals -= 10;
+    } else if (action === 'upgrade') {
+        state.energy -= 5;
+    } else if (action === 'research') {
+        state.minerals -= 5;
+        state.energy -= 5;
+    }
+    res.json({ success: true });
+});
+
+app.listen(3000, () => console.log('Web UI running on http://localhost:3000'));


### PR DESCRIPTION
## Summary
- initialize new `web-ui` Node project
- create basic Three.js scene rendering buildings
- add simple Express server exposing `/api/state` and `/api/action`
- include UI buttons that trigger build/upgrade/research actions via fetch

## Testing
- `pytest -q`
- `npm install three express ws` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68425556d4788327b948256d2305fba4