### PR TITLE
Fix upgrade index validation in Colony

### DIFF
--- a/colony.py
+++ b/colony.py
@@ -105,11 +105,13 @@ class Colony:
         return dict(bonuses)
 
     def upgrade_building(self, building_instance_index):
-        try:
-            building_to_upgrade = self.buildings[building_instance_index]
-        except IndexError:
+        if (
+            building_instance_index < 0
+            or building_instance_index >= len(self.buildings)
+        ):
             self.add_event_to_history("Error: Invalid building index for upgrade.")
             return False
+        building_to_upgrade = self.buildings[building_instance_index]
 
         current_upgrade_cost = building_to_upgrade.upgrade_cost()
 

--- a/tests/test_colony.py
+++ b/tests/test_colony.py
@@ -69,9 +69,25 @@ class TestBuildingUpgrades(unittest.TestCase):
         self.colony.upgrade_building(0) # Upgrade to level 2
 
         cost_lvl_2_to_3 = mine.upgrade_cost() # mine instance is updated
-        
+
         self.assertGreater(cost_lvl_2_to_3["Minerals"], cost_lvl_1_to_2["Minerals"])
         self.assertGreater(cost_lvl_2_to_3["Energy"], cost_lvl_1_to_2["Energy"])
+
+    def test_upgrade_building_invalid_index(self):
+        mine = Mine()
+        self.colony.add_building(mine)
+        self.colony.resources["Minerals"] = 100
+        self.colony.resources["Energy"] = 100
+
+        success_negative = self.colony.upgrade_building(-1)
+        self.assertFalse(success_negative)
+        self.assertEqual(self.colony.buildings[0].level, 1)
+        self.assertIn("Invalid building index", self.colony.event_history[0])
+
+        self.colony.event_history.clear()
+        success_oob = self.colony.upgrade_building(5)
+        self.assertFalse(success_oob)
+        self.assertIn("Invalid building index", self.colony.event_history[0])
 
 
 class TestResearchSystem(unittest.TestCase):


### PR DESCRIPTION
## Summary
- prevent negative or out-of-range indexes in `upgrade_building`
- add regression test for invalid indexes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425dce63088327b7b23f3beef61d51